### PR TITLE
Elargissement du tampon de lecture pour un \0

### DIFF
--- a/get_next_line.h
+++ b/get_next_line.h
@@ -23,7 +23,7 @@ typedef struct	s_fd
 {
 	int			fd;
 	int			ret;
-	char		buf[BUFF_SIZE];
+	char		buf[BUFF_SIZE + 1];
 	int			len;
 	int			start;
 }				t_fd;


### PR DESCRIPTION
Les chaines de caractere doivent etre terminees par
nu octet a 0, vu que le tampon est utilise avec des
fonctions qui s'attendent a voir un octet a 0 a la
fin, on l'ajoute pour que ca ne lise pas apres la
fin du tampon.